### PR TITLE
Изменение названия composer-пакета

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ PHP клиент для работы с MyTarget API (v1/v2).
 
 ### Install it via composer
 ```
-composer require dsl/my-target-api
+composer require dsl/my-target-sdk
 ```
 
 ### How to work with it?


### PR DESCRIPTION
Согласно packagist.org пакет называется dsl/my-target-sdk, а не dsl/my-target-api.
